### PR TITLE
Fix CSV schema export

### DIFF
--- a/docs/api-reference/database.md
+++ b/docs/api-reference/database.md
@@ -85,8 +85,12 @@ A pandas DataFrame with columns: `schema`, `table`, `column`, `data_type`
 Exports schema information to a CSV file:
 
 ```python
-def export_schema_csv(self, path: str) -> None:
-    """Export schema to CSV."""
+def export_schema_csv(
+    self,
+    path: str,
+    schemas: str | list[str] | None = None,
+) -> None:
+    """Export schema to CSV file."""
 ```
 
 #### Parameters
@@ -94,12 +98,14 @@ def export_schema_csv(self, path: str) -> None:
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `path` | `str` | Path to the output CSV file |
+| `schemas` | `str \| list[str] \| None` | Optional schema name or list of schema names to filter results |
 
 ### Connection Configuration
 
 The `PostgreSQLConnector` supports multiple configuration sources:
 
 1. **Direct parameters** in constructor
+
 2. **YAML configuration file**:
    ```yaml
    # database.yml
@@ -110,13 +116,24 @@ The `PostgreSQLConnector` supports multiple configuration sources:
      username: username
      password: password
    ```
+
 3. **Environment variables**:
-   - `DB_HOST`
-   - `DB_PORT`
-   - `DB_NAME`
-   - `DB_USER`
-   - `DB_PASSWORD`
-4. **PostgreSQL password file** (`~/.pgpass`)
+
+    - `DB_HOST`
+    - `DB_PORT`
+    - `DB_NAME`
+    - `DB_USER`
+    - `DB_PASSWORD`
+
+4. **PostgreSQL password file** (`~/.pgpass`): The connector will automatically check 
+this file for matching credentials if no password is provided through other methods.
+The file format should follow PostgreSQL standards with each line containing:
+
+```bash
+hostname:port:database:username:password
+```
+
+where wildcards (*) can be used to match multiple values.
 
 ### Usage Examples
 

--- a/sqldeps/database/base.py
+++ b/sqldeps/database/base.py
@@ -5,7 +5,7 @@ from typing import Any
 import pandas as pd
 from dotenv import load_dotenv
 
-load_dotenv(override=True)
+load_dotenv()
 
 
 class SQLBaseConnector(ABC):

--- a/sqldeps/database/base.py
+++ b/sqldeps/database/base.py
@@ -5,7 +5,7 @@ from typing import Any
 import pandas as pd
 from dotenv import load_dotenv
 
-load_dotenv()
+load_dotenv(override=True)
 
 
 class SQLBaseConnector(ABC):
@@ -64,7 +64,11 @@ class SQLBaseConnector(ABC):
         """Get database schema information."""
         pass
 
-    def export_schema_csv(self, path: str) -> None:
+    def export_schema_csv(
+        self,
+        path: str,
+        schemas: str | list[str] | None = None,
+    ) -> None:
         """Export schema to CSV file."""
-        df = self.get_schema()
+        df = self.get_schema(schemas)
         df.to_csv(path, index=False)

--- a/sqldeps/database/postgresql.py
+++ b/sqldeps/database/postgresql.py
@@ -283,8 +283,3 @@ class PostgreSQLConnector(SQLBaseConnector):
                     )
 
         return pd.DataFrame(schema_data)
-
-    def export_schema_csv(self, path: str) -> None:
-        """Export schema to CSV."""
-        df = self.get_schema_df()
-        df.to_csv(path, index=False)

--- a/sqldeps/llm_parsers/__init__.py
+++ b/sqldeps/llm_parsers/__init__.py
@@ -7,7 +7,7 @@ from .deepseek import DeepseekExtractor
 from .groq import GroqExtractor
 from .openai import OpenaiExtractor
 
-load_dotenv(override=True)
+load_dotenv()
 
 DEFAULTS = {
     "groq": {"class": GroqExtractor, "model": "llama-3.3-70b-versatile"},


### PR DESCRIPTION
Fixed database schema export by:

- Removing a call to the nonexistent method `get_schema_df()`.
- Adding support to schemas and moving the function to `SQLBaseConnector`.